### PR TITLE
use aware datetime + better schedule storing

### DIFF
--- a/beatx/schedulers.py
+++ b/beatx/schedulers.py
@@ -56,7 +56,6 @@ class Scheduler(BaseScheduler):
 
     def __init__(self, app, *args, **kwargs):
         self.store = self.get_store(app)
-        self._store_schedule = {}
 
         super().__init__(app, *args, **kwargs)
 
@@ -74,20 +73,8 @@ class Scheduler(BaseScheduler):
 
     def setup_schedule(self):
         if self.store.has_locked():
-            self._store_schedule = self.store.load_entries()
             self.merge_inplace(self.app.conf.beat_schedule)
-            self.install_default_entries(self.schedule)
-
-    def get_schedule(self):
-        if not self.store.has_locked():
-            return super().get_schedule()
-        return self._store_schedule
-
-    def set_schedule(self, schedule):
-        if not self.store.has_locked():
-            super().set_schedule(schedule)
-        self._store_schedule = schedule
-    schedule = property(get_schedule, set_schedule)
+            self.install_default_entries(self.store.load_entries())
 
     def sync(self):
         if not self.store.has_locked():

--- a/beatx/schedulers.py
+++ b/beatx/schedulers.py
@@ -124,3 +124,7 @@ class Scheduler(BaseScheduler):
         if self.store.has_locked():
             self.store.release_lock()
             logger.info('beatX: Lock released.')
+
+    @property
+    def info(self):
+        return '    . store -> {}'.format(self.store.__class__.__module__)

--- a/beatx/schedulers.py
+++ b/beatx/schedulers.py
@@ -77,7 +77,6 @@ class Scheduler(BaseScheduler):
             self._store_schedule = self.store.load_entries()
             self.merge_inplace(self.app.conf.beat_schedule)
             self.install_default_entries(self.schedule)
-            self.sync()
 
     def get_schedule(self):
         if not self.store.has_locked():

--- a/beatx/serializer.py
+++ b/beatx/serializer.py
@@ -2,10 +2,9 @@ from datetime import datetime
 
 from celery.beat import ScheduleEntry
 from celery.schedules import crontab, schedule, solar
+from celery.utils.time import maybe_iso8601
 
 __all__ = ('serialize_entry', 'deserialize_entry')
-
-DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
 
 def serialize_entry(entry):
@@ -51,11 +50,11 @@ def deserialize_entry(entry):
 
 
 def encode_datetime(dt):
-    return dt.strftime(DATETIME_FORMAT) if dt else None
+    return dt.isoformat() if dt else None
 
 
 def decode_datetime(s):
-    return datetime.strptime(s, DATETIME_FORMAT) if s else None
+    return maybe_iso8601(s) if s else None
 
 
 def encode_schedule(value):

--- a/beatx/store/redis.py
+++ b/beatx/store/redis.py
@@ -21,11 +21,13 @@ class Store:
         }
 
     def save_entries(self, entries):
-        self.rdb.hmset(self.SCHEDULE_KEY, {
-            name: json.dumps(
-                serializer.serialize_entry(entry)
-            ) for name, entry in entries.items()
-        })
+        self.rdb.delete(self.SCHEDULE_KEY)
+        if entries:
+            self.rdb.hmset(self.SCHEDULE_KEY, {
+                name: json.dumps(
+                    serializer.serialize_entry(entry)
+                ) for name, entry in entries.items()
+            })
 
     def has_locked(self):
         return self.lock is not None


### PR DESCRIPTION
Hello @mixkorshun ,

the PR proposal solve two little issues with scheduler interaction:

- use aware datetime solve an issue with last_run date if timezone is configured (in fact after the first reload the stored datetime was interpreted as UTC also if it was relative to a timezone)

- changed a bit the interaction between the scheduler and the store. Now changes on beat_schedule config are synced correctly. This solve the issue #2 too.

Have a nice day