### PR TITLE
Fix setup_schedule to allow updating the app beat schedule

### DIFF
--- a/beatx/schedulers.py
+++ b/beatx/schedulers.py
@@ -73,9 +73,9 @@ class Scheduler(BaseScheduler):
 
     def setup_schedule(self):
         if self.store.has_locked():
-            self.merge_inplace(self.app.conf.beat_schedule)
             self.install_default_entries(self.schedule)
             self.update_from_dict(self.store.load_entries())
+            self.merge_inplace(self.app.conf.beat_schedule)
 
             self.sync()
 


### PR DESCRIPTION
Currently with version 0.4.1, `beatx.schedulers.Scheduler.setup_schedule` loads and merge the beat schedule configuration in the following order:

1. The app config schedule (the one you define within your app logic)
2. The default celery schedule configs (if any enabled)
3. The previously stored config schedule (app + default), if any
4. Synchronize and store the retrieved schedule

Obviously, the first time the `celery beat` will start, the proper app schedule will be stored and executed.
However, if one were to update the schedule defined within the app and `celery beat` restarted, the new app schedule would not be taken into account as the previously stored schedule would override it.

This PR aims at fixing this behaviour, by simply changing the order of loading the schedule in `beatx.schedulers.Scheduler.setup_schedule`:

1. The default celery schedule configs (if any enabled)
2. The previously stored config schedule (app + default), if any
3. The app config schedule (the one you define within your app logic)
4. Synchronize and store the retrieved schedule

This way, every time `celery beat` starts, it should guarantee it always has the latest app schedule configured and stored.

If I overlooked a certain use-case, please let me know, I'd be happy to find a more satisfying solution.