### PR TITLE
Ensure that the lock is owned by the process which creates it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 /.idea
 /.cache
 /.eggs

--- a/beatx/store/redis.py
+++ b/beatx/store/redis.py
@@ -28,7 +28,7 @@ class Store:
         })
 
     def has_locked(self):
-        return self.lock is not None
+        return self.lock is not None and self.lock.owned()
 
     def acquire_lock(self, lock_ttl=60):
         lock = self.rdb.lock(self.LOCK_KEY, timeout=lock_ttl, sleep=1)

--- a/beatx/tests/test_store.py
+++ b/beatx/tests/test_store.py
@@ -67,7 +67,7 @@ class TestRedisStore:
         assert acquired is True
         assert self.store.has_locked() is True
 
-        assert self.store.rdb.exists(self.store.LOCK_KEY) is True
+        assert self.store.rdb.exists(self.store.LOCK_KEY) is 1
 
     def test_acquire_exists_lock(self):
         self.store.rdb.lock(
@@ -92,4 +92,4 @@ class TestRedisStore:
         self.store.release_lock()
         assert self.store.has_locked() is False
 
-        assert self.store.rdb.exists(self.store.LOCK_KEY) is False
+        assert self.store.rdb.exists(self.store.LOCK_KEY) is 0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,7 @@
 pytest
 pytest-cov
 
+celery
+
 redis
 ephem


### PR DESCRIPTION
In the microservices world, there can be a possibility that two separate clients (celery-beatx) think that they make the lock. 
So I added to the has_lock function to ensure that the lock is the process lock (under the hood the lock has a unique UUID in it).
Additionally, I have fixed the tests.
